### PR TITLE
Set time zone on stampFormat

### DIFF
--- a/PRE_PROCESSOR.groovy
+++ b/PRE_PROCESSOR.groovy
@@ -29,6 +29,7 @@ def now = new Date()
 def amzFormat = new SimpleDateFormat( "yyyyMMdd'T'HHmmss'Z'" )
 def stampFormat = new SimpleDateFormat( "yyyyMMdd" )
 amzFormat.setTimeZone(TimeZone.getTimeZone("UTC"));  //server timezone
+stampFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 def amzDate = amzFormat.format(now)
 def dateStamp = stampFormat.format(now)
 vars.put("x_amz_date", amzDate)


### PR DESCRIPTION
Time zones need to be set on both timestamps to avoid a conflict between local time and AWS time, creating a signature error when it's a day later in one time zone.